### PR TITLE
feat: remove self-destruct from create3deployer

### DIFF
--- a/contracts/deploy/Create3.sol
+++ b/contracts/deploy/Create3.sol
@@ -18,8 +18,6 @@ contract CreateDeployer {
                 revert(0, 0)
             }
         }
-
-        selfdestruct(payable(msg.sender));
     }
 }
 

--- a/contracts/test/MockDepositReceiver.sol
+++ b/contracts/test/MockDepositReceiver.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.9;
+
+// Simple contract that self-destructs in constructor
+contract MockDepositReceiver {
+    constructor(address refundAddress) {
+        if (refundAddress == address(0)) refundAddress = msg.sender;
+
+        selfdestruct(payable(refundAddress));
+    }
+
+    // @dev This function is for receiving Ether from unwrapping WETH9
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {}
+}


### PR DESCRIPTION
Removed the self-destruct line from Create3Deployer because it will be deprecated in the future. 

Added test to show that we can no longer redeploy user contracts that have been destroyed.