### PR TITLE
fix(TimeLock): internal _getTimeLockEta

### DIFF
--- a/contracts/utils/TimeLock.sol
+++ b/contracts/utils/TimeLock.sol
@@ -89,7 +89,7 @@ contract TimeLock is ITimeLock {
     /**
      * @dev Returns the timestamp after which the timelock with the given hash can be executed.
      */
-    function _getTimeLockEta(bytes32 hash) private view returns (uint256 eta) {
+    function _getTimeLockEta(bytes32 hash) internal view returns (uint256 eta) {
         bytes32 key = keccak256(abi.encodePacked(PREFIX_TIME_LOCK, hash));
 
         assembly {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@axelar-network/axelar-gmp-sdk-solidity",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-gmp-sdk-solidity",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "ISC",
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-gmp-sdk-solidity",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Solidity GMP SDK and utilities provided by Axelar for cross-chain development",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* [x] `TimeLock`: making `_getTimeLockEta` internal so it can be accessed by inheriting contracts
