### PR TITLE
fix(gitignore): interfaces relative path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,4 @@ dist
 
 # Build
 artifacts
-interfaces
+/interfaces


### PR DESCRIPTION
PR to fix interfaces relative path in .gitignore so it no longer overshadows contracts/interfaces