### PR TITLE
refactor(FinalProxy): hard-coding the final deploy salt

### DIFF
--- a/contracts/express/ExpressExecutorTracker.sol
+++ b/contracts/express/ExpressExecutorTracker.sol
@@ -5,18 +5,16 @@ pragma solidity ^0.8.0;
 import { IAxelarExpressExecutable } from '../interfaces/IAxelarExpressExecutable.sol';
 
 abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
-    uint256 private constant PREFIX_EXPRESS_EXECUTE = uint256(keccak256('express-execute'));
-    uint256 private constant PREFIX_EXPRESS_EXECUTE_WTIH_TOKEN = uint256(keccak256('express-execute-with-token'));
+    bytes32 internal constant PREFIX_EXPRESS_EXECUTE = keccak256('express-execute');
+    bytes32 internal constant PREFIX_EXPRESS_EXECUTE_WITH_TOKEN = keccak256('express-execute-with-token');
 
     function _expressExecuteSlot(
         bytes32 commandId,
         string calldata sourceChain,
         string calldata sourceAddress,
         bytes32 payloadHash
-    ) internal pure returns (uint256 slot) {
-        slot = uint256(
-            keccak256(abi.encode(PREFIX_EXPRESS_EXECUTE, commandId, sourceChain, sourceAddress, payloadHash))
-        );
+    ) internal pure returns (bytes32 slot) {
+        slot = keccak256(abi.encode(PREFIX_EXPRESS_EXECUTE, commandId, sourceChain, sourceAddress, payloadHash));
     }
 
     function _expressExecuteWithTokenSlot(
@@ -26,18 +24,16 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         bytes32 payloadHash,
         string calldata symbol,
         uint256 amount
-    ) internal pure returns (uint256 slot) {
-        slot = uint256(
-            keccak256(
-                abi.encode(
-                    PREFIX_EXPRESS_EXECUTE_WTIH_TOKEN,
-                    commandId,
-                    sourceChain,
-                    sourceAddress,
-                    payloadHash,
-                    symbol,
-                    amount
-                )
+    ) internal pure returns (bytes32 slot) {
+        slot = keccak256(
+            abi.encode(
+                PREFIX_EXPRESS_EXECUTE_WITH_TOKEN,
+                commandId,
+                sourceChain,
+                sourceAddress,
+                payloadHash,
+                symbol,
+                amount
             )
         );
     }
@@ -48,7 +44,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         string calldata sourceAddress,
         bytes32 payloadHash
     ) external view returns (address expressExecutor) {
-        uint256 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
+        bytes32 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
 
         assembly {
             expressExecutor := sload(slot)
@@ -63,7 +59,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         string calldata symbol,
         uint256 amount
     ) external view returns (address expressExecutor) {
-        uint256 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
+        bytes32 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
 
         assembly {
             expressExecutor := sload(slot)
@@ -77,7 +73,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         bytes32 payloadHash,
         address expressExecutor
     ) internal {
-        uint256 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
+        bytes32 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
         address currentExecutor;
 
         assembly {
@@ -100,7 +96,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         uint256 amount,
         address expressExecutor
     ) internal {
-        uint256 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
+        bytes32 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
         address currentExecutor;
 
         assembly {
@@ -120,7 +116,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         string calldata sourceAddress,
         bytes32 payloadHash
     ) internal returns (address expressExecutor) {
-        uint256 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
+        bytes32 slot = _expressExecuteSlot(commandId, sourceChain, sourceAddress, payloadHash);
 
         assembly {
             expressExecutor := sload(slot)
@@ -138,7 +134,7 @@ abstract contract ExpressExecutorTracker is IAxelarExpressExecutable {
         string calldata symbol,
         uint256 amount
     ) internal returns (address expressExecutor) {
-        uint256 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
+        bytes32 slot = _expressExecuteWithTokenSlot(commandId, sourceChain, sourceAddress, payloadHash, symbol, amount);
 
         assembly {
             expressExecutor := sload(slot)

--- a/contracts/test/express/TestAxelarExpressExecutable.sol
+++ b/contracts/test/express/TestAxelarExpressExecutable.sol
@@ -8,6 +8,6 @@ contract TestAxelarExpressExecutable is AxelarExpressExecutable {
     constructor(address gateway_) AxelarExpressExecutable(gateway_) {
         if (PREFIX_EXPRESS_EXECUTE != keccak256('express-execute')) revert('invalid express execute prefix');
         if (PREFIX_EXPRESS_EXECUTE_WITH_TOKEN != keccak256('express-execute-with-token'))
-            revert('invalid express execute with token prefix');
+            revert('invalid prefix');
     }
 }

--- a/contracts/test/express/TestAxelarExpressExecutable.sol
+++ b/contracts/test/express/TestAxelarExpressExecutable.sol
@@ -5,5 +5,9 @@ pragma solidity ^0.8.0;
 import { AxelarExpressExecutable } from '../../express/AxelarExpressExecutable.sol';
 
 contract TestAxelarExpressExecutable is AxelarExpressExecutable {
-    constructor(address gateway_) AxelarExpressExecutable(gateway_) {}
+    constructor(address gateway_) AxelarExpressExecutable(gateway_) {
+        if (PREFIX_EXPRESS_EXECUTE != keccak256('express-execute')) revert('invalid express execute prefix');
+        if (PREFIX_EXPRESS_EXECUTE_WITH_TOKEN != keccak256('express-execute-with-token'))
+            revert('invalid express execute with token prefix');
+    }
 }

--- a/contracts/test/express/TestAxelarExpressExecutable.sol
+++ b/contracts/test/express/TestAxelarExpressExecutable.sol
@@ -6,8 +6,9 @@ import { AxelarExpressExecutable } from '../../express/AxelarExpressExecutable.s
 
 contract TestAxelarExpressExecutable is AxelarExpressExecutable {
     constructor(address gateway_) AxelarExpressExecutable(gateway_) {
-        if (PREFIX_EXPRESS_EXECUTE != keccak256('express-execute')) revert('invalid express execute prefix');
-        if (PREFIX_EXPRESS_EXECUTE_WITH_TOKEN != keccak256('express-execute-with-token'))
-            revert('invalid prefix');
+        if (
+            PREFIX_EXPRESS_EXECUTE != keccak256('express-execute') ||
+            PREFIX_EXPRESS_EXECUTE_WITH_TOKEN != keccak256('express-execute-with-token')
+        ) revert('invalid express execute prefix');
     }
 }

--- a/contracts/test/upgradable/ProxyTest.sol
+++ b/contracts/test/upgradable/ProxyTest.sol
@@ -9,7 +9,12 @@ contract ProxyTest is Proxy {
         address implementationAddress,
         address owner,
         bytes memory setupParams
-    ) Proxy(implementationAddress, owner, setupParams) {}
+    ) Proxy(implementationAddress, owner, setupParams) {
+        if (_IMPLEMENTATION_SLOT != bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1))
+            revert('invalid implementation slot');
+
+        if (_OWNER_SLOT != keccak256('owner')) revert('invalid owner slot');
+    }
 
     function contractId() internal pure override returns (bytes32) {
         return keccak256('test');

--- a/contracts/test/upgradable/TestFinalProxy.sol
+++ b/contracts/test/upgradable/TestFinalProxy.sol
@@ -1,4 +1,4 @@
-import '../../upgradable/FinalProxy.sol';
+import { FinalProxy } from '../../upgradable/FinalProxy.sol';
 
 contract TestFinalProxy is FinalProxy {
     constructor(
@@ -7,6 +7,6 @@ contract TestFinalProxy is FinalProxy {
         bytes memory setupParams
     ) FinalProxy(implementationAddress, owner, setupParams) {
         if (FINAL_IMPLEMENTATION_SALT != bytes32(uint256(keccak256('final-implementation')) - 1))
-            revert('invalid final implementation salt');
+            revert('invalid final salt');
     }
 }

--- a/contracts/test/upgradable/TestFinalProxy.sol
+++ b/contracts/test/upgradable/TestFinalProxy.sol
@@ -1,0 +1,12 @@
+import '../../upgradable/FinalProxy.sol';
+
+contract TestFinalProxy is FinalProxy {
+    constructor(
+        address implementationAddress,
+        address owner,
+        bytes memory setupParams
+    ) FinalProxy(implementationAddress, owner, setupParams) {
+        if (FINAL_IMPLEMENTATION_SALT != bytes32(uint256(keccak256('final-implementation')) - 1))
+            revert('invalid final implementation salt');
+    }
+}

--- a/contracts/test/upgradable/TestFinalProxy.sol
+++ b/contracts/test/upgradable/TestFinalProxy.sol
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
 import { FinalProxy } from '../../upgradable/FinalProxy.sol';
 
 contract TestFinalProxy is FinalProxy {

--- a/contracts/test/upgradable/UpgradableTest.sol
+++ b/contracts/test/upgradable/UpgradableTest.sol
@@ -5,6 +5,12 @@ pragma solidity ^0.8.0;
 import { Upgradable } from '../../upgradable/Upgradable.sol';
 
 contract UpgradableTest is Upgradable {
+    constructor() Upgradable() {
+        if (_IMPLEMENTATION_SLOT != bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)) {
+            revert('invalid implementation slot');
+        }
+    }
+
     function contractId() external pure override returns (bytes32) {
         return keccak256('test');
     }

--- a/contracts/test/utils/TestOwnable.sol
+++ b/contracts/test/utils/TestOwnable.sol
@@ -9,7 +9,10 @@ contract TestOwnable is Ownable {
 
     event NumAdded(uint256 num);
 
-    constructor(address _owner) Ownable(_owner) {}
+    constructor(address _owner) Ownable(_owner) {
+        if (_OWNER_SLOT != keccak256('owner')) revert('invalid owner slot');
+        if (_OWNERSHIP_TRANSFER_SLOT != keccak256('ownership-transfer')) revert('invalid ownership transfer slot');
+    }
 
     function setNum(uint256 _num) external payable onlyOwner returns (bool) {
         num = _num;

--- a/contracts/test/utils/TimeLockTest.sol
+++ b/contracts/test/utils/TimeLockTest.sol
@@ -9,7 +9,9 @@ contract TimeLockTest is TimeLock {
 
     event NumUpdated(uint256 newNum);
 
-    constructor(uint256 _minimumTimeDelay) TimeLock(_minimumTimeDelay) {}
+    constructor(uint256 _minimumTimeDelay) TimeLock(_minimumTimeDelay) {
+        if (PREFIX_TIME_LOCK != keccak256('time-lock')) revert('invalid time-lock slot');
+    }
 
     function getNum() external view returns (uint256) {
         return num;

--- a/contracts/upgradable/FinalProxy.sol
+++ b/contracts/upgradable/FinalProxy.sol
@@ -17,7 +17,8 @@ import { Proxy } from './Proxy.sol';
  */
 contract FinalProxy is Create3, Proxy, IFinalProxy {
     // FINAL_IMPLEMENTATION_SALT = bytes32(uint256(keccak256('final-implementation')) - 1);
-    bytes32 internal constant FINAL_IMPLEMENTATION_SALT = 0x80df4dfef2d6527a47431f6f203697684e26d83f81418443821420778d4c4e8c;
+    bytes32 internal constant FINAL_IMPLEMENTATION_SALT =
+        0x80df4dfef2d6527a47431f6f203697684e26d83f81418443821420778d4c4e8c;
 
     /**
      * @dev Constructs a FinalProxy contract with a given implementation address, owner, and setup parameters.

--- a/contracts/upgradable/FinalProxy.sol
+++ b/contracts/upgradable/FinalProxy.sol
@@ -16,7 +16,7 @@ import { Proxy } from './Proxy.sol';
  * the IFinalProxy interface.
  */
 contract FinalProxy is Create3, Proxy, IFinalProxy {
-    // FINAL_IMPLEMENTATION_SALT = bytes32(uint256(keccak256('final-implementation')) - 1);
+    // bytes32(uint256(keccak256('final-implementation')) - 1);
     bytes32 internal constant FINAL_IMPLEMENTATION_SALT =
         0x80df4dfef2d6527a47431f6f203697684e26d83f81418443821420778d4c4e8c;
 

--- a/contracts/upgradable/FinalProxy.sol
+++ b/contracts/upgradable/FinalProxy.sol
@@ -16,7 +16,8 @@ import { Proxy } from './Proxy.sol';
  * the IFinalProxy interface.
  */
 contract FinalProxy is Create3, Proxy, IFinalProxy {
-    bytes32 internal constant FINAL_IMPLEMENTATION_SALT = bytes32(uint256(keccak256('final-implementation')) - 1);
+    // FINAL_IMPLEMENTATION_SALT = bytes32(uint256(keccak256('final-implementation')) - 1);
+    bytes32 internal constant FINAL_IMPLEMENTATION_SALT = 0x80df4dfef2d6527a47431f6f203697684e26d83f81418443821420778d4c4e8c;
 
     /**
      * @dev Constructs a FinalProxy contract with a given implementation address, owner, and setup parameters.

--- a/test/upgradable/Proxy.js
+++ b/test/upgradable/Proxy.js
@@ -183,7 +183,10 @@ describe('Proxy', async () => {
     let differentProxyImplementation;
 
     beforeEach(async () => {
-      finalProxyFactory = await ethers.getContractFactory('FinalProxy', owner);
+      finalProxyFactory = await ethers.getContractFactory(
+        'TestFinalProxy',
+        owner,
+      );
       proxyImplementationFactory = await ethers.getContractFactory(
         'ProxyImplementation',
         owner,


### PR DESCRIPTION
* [x] `FinalProxy`: hard-coding deploy salt `bytes32(uint256(keccak256('final-implementation')) - 1)`
* [x] Storage slot constants: adding tests coverage