### PR TITLE
fix(Upgradable): storing new implementation before the delegate call

### DIFF
--- a/contracts/upgradable/Upgradable.sol
+++ b/contracts/upgradable/Upgradable.sol
@@ -51,6 +51,10 @@ abstract contract Upgradable is Ownable, Implementation, IUpgradable {
 
         if (newImplementationCodeHash != newImplementation.codehash) revert InvalidCodeHash();
 
+        assembly {
+            sstore(_IMPLEMENTATION_SLOT, newImplementation)
+        }
+
         emit Upgraded(newImplementation);
 
         if (params.length > 0) {
@@ -58,10 +62,6 @@ abstract contract Upgradable is Ownable, Implementation, IUpgradable {
             (bool success, ) = newImplementation.delegatecall(abi.encodeWithSelector(this.setup.selector, params));
 
             if (!success) revert SetupFailed();
-        }
-
-        assembly {
-            sstore(_IMPLEMENTATION_SLOT, newImplementation)
         }
     }
 

--- a/test/upgradable/Upgradable.js
+++ b/test/upgradable/Upgradable.js
@@ -43,20 +43,6 @@ describe('Upgradable', () => {
             expect(await implementation.implementation()).to.eq(AddressZero);
         });
 
-        it('should revert on upgrade with invalid contract ID', async () => {
-            const invalidUpgradableTestFactory = await ethers.getContractFactory('InvalidUpgradableTest', ownerWallet);
-
-            const invalidUpgradableTest = await invalidUpgradableTestFactory.deploy().then((d) => d.deployed());
-
-            const implementationCode = await ethers.provider.getCode(invalidUpgradableTest.address);
-
-            const implementationCodeHash = keccak256(implementationCode);
-
-            await expect(
-                upgradable.upgrade(invalidUpgradableTest.address, implementationCodeHash, '0x'),
-            ).to.be.revertedWithCustomError(upgradable, 'InvalidImplementation');
-        });
-
         it('should upgrade to a new implementation', async () => {
             const oldImplementation = await upgradable.implementation();
 
@@ -108,7 +94,7 @@ describe('Upgradable', () => {
         });
 
         it('should revert on upgrade with invalid code hash', async () => {
-            const invalidCodeHash = keccak256(0);
+            const invalidCodeHash = keccak256('0');
 
             await expect(upgradable.upgrade(upgradable.address, invalidCodeHash, '0x')).to.be.revertedWithCustomError(
                 upgradable,

--- a/test/upgradable/Upgradable.js
+++ b/test/upgradable/Upgradable.js
@@ -26,9 +26,8 @@ describe('Upgradable', () => {
         upgradableTestFactory = await ethers.getContractFactory('UpgradableTest', ownerWallet);
 
         create3DeployerFactory = await ethers.getContractFactory('Create3Deployer', ownerWallet);
-    });
 
-    beforeEach(async () => {
+
         const create3Deployer = await create3DeployerFactory.deploy().then((d) => d.deployed());
 
         upgradable = await deployCreate3Upgradable(create3Deployer.address, ownerWallet, Upgradable, Proxy, []);
@@ -94,16 +93,16 @@ describe('Upgradable', () => {
     });
 
     it('should revert on upgrade if setup fails', async () => {
-        const implementation = await upgradable.implementation();
+        const newImplementation = await upgradableTestFactory.deploy().then((d) => d.deployed());
 
         const setupParams = '0x00';
 
-        const implementationCode = await ethers.provider.getCode(implementation);
+        const implementationCode = await ethers.provider.getCode(newImplementation.address);
 
         const implementationCodeHash = keccak256(implementationCode);
 
         await expect(
-            upgradable.upgrade(implementation, implementationCodeHash, setupParams),
+            upgradable.upgrade(newImplementation.address, implementationCodeHash, setupParams),
         ).to.be.revertedWithCustomError(upgradable, 'SetupFailed');
     });
 

--- a/test/upgradable/Upgradable.js
+++ b/test/upgradable/Upgradable.js
@@ -26,99 +26,118 @@ describe('Upgradable', () => {
         upgradableTestFactory = await ethers.getContractFactory('UpgradableTest', ownerWallet);
 
         create3DeployerFactory = await ethers.getContractFactory('Create3Deployer', ownerWallet);
-
-
-        const create3Deployer = await create3DeployerFactory.deploy().then((d) => d.deployed());
-
-        upgradable = await deployCreate3Upgradable(create3Deployer.address, ownerWallet, Upgradable, Proxy, []);
     });
 
-    it('should store implementation address in the proxy, not the implementation', async () => {
-        const implementationAddress = await upgradable.implementation();
+    describe('positive tests', () => {
+        beforeEach(async () => {
+            const create3Deployer = await create3DeployerFactory.deploy().then((d) => d.deployed());
 
-        const implementation = upgradableTestFactory.attach(implementationAddress);
+            upgradable = await deployCreate3Upgradable(create3Deployer.address, ownerWallet, Upgradable, Proxy, []);
+        });
 
-        expect(await implementation.implementation()).to.eq(AddressZero);
+        it('should store implementation address in the proxy, not the implementation', async () => {
+            const implementationAddress = await upgradable.implementation();
+
+            const implementation = upgradableTestFactory.attach(implementationAddress);
+
+            expect(await implementation.implementation()).to.eq(AddressZero);
+        });
+
+        it('should revert on upgrade with invalid contract ID', async () => {
+            const invalidUpgradableTestFactory = await ethers.getContractFactory('InvalidUpgradableTest', ownerWallet);
+
+            const invalidUpgradableTest = await invalidUpgradableTestFactory.deploy().then((d) => d.deployed());
+
+            const implementationCode = await ethers.provider.getCode(invalidUpgradableTest.address);
+
+            const implementationCodeHash = keccak256(implementationCode);
+
+            await expect(
+                upgradable.upgrade(invalidUpgradableTest.address, implementationCodeHash, '0x'),
+            ).to.be.revertedWithCustomError(upgradable, 'InvalidImplementation');
+        });
+
+        it('should upgrade to a new implementation', async () => {
+            const oldImplementation = await upgradable.implementation();
+
+            await upgradeUpgradable(upgradable.address, ownerWallet, Upgradable, []);
+
+            const newImplementation = await upgradable.implementation();
+
+            expect(newImplementation).not.to.be.equal(oldImplementation);
+        });
+
+        it('should upgrade to a new implementation with setup params', async () => {
+            const oldImplementation = await upgradable.implementation();
+
+            const setupParams = defaultAbiCoder.encode(['uint256'], [10]);
+
+            await upgradeUpgradable(upgradable.address, ownerWallet, Upgradable, [], setupParams);
+
+            const newImplementation = await upgradable.implementation();
+
+            expect(newImplementation).not.to.be.equal(oldImplementation);
+        });
+
+        it('should transfer ownership', async () => {
+            await upgradable.connect(ownerWallet).transferOwnership(userWallet.address);
+
+            expect(await upgradable.owner()).to.be.equal(userWallet.address);
+        });
     });
 
-    it('should revert on upgrade if called by non-owner', async () => {
-        await expect(
-            upgradable.connect(userWallet).upgrade(AddressZero, keccak256(0), '0x'),
-        ).to.be.revertedWithCustomError(upgradable, 'NotOwner');
-    });
+    describe('negative tests', () => {
+        before(async () => {
+            const create3Deployer = await create3DeployerFactory.deploy().then((d) => d.deployed());
 
-    it('should revert on upgrade with invalid contract ID', async () => {
-        const invalidUpgradableTestFactory = await ethers.getContractFactory('InvalidUpgradableTest', ownerWallet);
+            upgradable = await deployCreate3Upgradable(create3Deployer.address, ownerWallet, Upgradable, Proxy, []);
+        });
 
-        const invalidUpgradableTest = await invalidUpgradableTestFactory.deploy().then((d) => d.deployed());
+        it('should revert on upgrade with invalid contract ID', async () => {
+            const invalidUpgradableTestFactory = await ethers.getContractFactory('InvalidUpgradableTest', ownerWallet);
 
-        const implementationCode = await ethers.provider.getCode(invalidUpgradableTest.address);
+            const invalidUpgradableTest = await invalidUpgradableTestFactory.deploy().then((d) => d.deployed());
 
-        const implementationCodeHash = keccak256(implementationCode);
+            const implementationCode = await ethers.provider.getCode(invalidUpgradableTest.address);
 
-        await expect(
-            upgradable.upgrade(invalidUpgradableTest.address, implementationCodeHash, '0x'),
-        ).to.be.revertedWithCustomError(upgradable, 'InvalidImplementation');
-    });
+            const implementationCodeHash = keccak256(implementationCode);
 
-    it('should revert on upgrade with invalid code hash', async () => {
-        const invalidCodeHash = keccak256(0);
+            await expect(
+                upgradable.upgrade(invalidUpgradableTest.address, implementationCodeHash, '0x'),
+            ).to.be.revertedWithCustomError(upgradable, 'InvalidImplementation');
+        });
 
-        await expect(upgradable.upgrade(upgradable.address, invalidCodeHash, '0x')).to.be.revertedWithCustomError(
-            upgradable,
-            'InvalidCodeHash',
-        );
-    });
+        it('should revert on upgrade with invalid code hash', async () => {
+            const invalidCodeHash = keccak256(0);
 
-    it('should upgrade to a new implementation', async () => {
-        const oldImplementation = await upgradable.implementation();
+            await expect(upgradable.upgrade(upgradable.address, invalidCodeHash, '0x')).to.be.revertedWithCustomError(
+                upgradable,
+                'InvalidCodeHash',
+            );
+        });
 
-        await upgradeUpgradable(upgradable.address, ownerWallet, Upgradable, []);
+        it('should revert on upgrade if setup fails', async () => {
+            const newImplementation = await upgradableTestFactory.deploy().then((d) => d.deployed());
 
-        const newImplementation = await upgradable.implementation();
+            const setupParams = '0x00';
 
-        expect(newImplementation).not.to.be.equal(oldImplementation);
-    });
+            const implementationCode = await ethers.provider.getCode(newImplementation.address);
 
-    it('should upgrade to a new implementation with setup params', async () => {
-        const oldImplementation = await upgradable.implementation();
+            const implementationCodeHash = keccak256(implementationCode);
 
-        const setupParams = defaultAbiCoder.encode(['uint256'], [10]);
+            await expect(
+                upgradable.upgrade(newImplementation.address, implementationCodeHash, setupParams),
+            ).to.be.revertedWithCustomError(upgradable, 'SetupFailed');
+        });
 
-        await upgradeUpgradable(upgradable.address, ownerWallet, Upgradable, [], setupParams);
+        it('should revert if setup is called on the implementation', async () => {
+            const implementationAddress = await upgradable.implementation();
+            const setupParams = '0x';
 
-        const newImplementation = await upgradable.implementation();
+            const implementation = await upgradableTestFactory.attach(implementationAddress);
 
-        expect(newImplementation).not.to.be.equal(oldImplementation);
-    });
-
-    it('should revert on upgrade if setup fails', async () => {
-        const newImplementation = await upgradableTestFactory.deploy().then((d) => d.deployed());
-
-        const setupParams = '0x00';
-
-        const implementationCode = await ethers.provider.getCode(newImplementation.address);
-
-        const implementationCodeHash = keccak256(implementationCode);
-
-        await expect(
-            upgradable.upgrade(newImplementation.address, implementationCodeHash, setupParams),
-        ).to.be.revertedWithCustomError(upgradable, 'SetupFailed');
-    });
-
-    it('should transfer ownership', async () => {
-        await upgradable.connect(ownerWallet).transferOwnership(userWallet.address);
-
-        expect(await upgradable.owner()).to.be.equal(userWallet.address);
-    });
-
-    it('should revert if setup is called on the implementation', async () => {
-        const implementationAddress = await upgradable.implementation();
-        const setupParams = '0x';
-
-        const implementation = await upgradableTestFactory.attach(implementationAddress);
-
-        // call setup on the implementation
-        await expect(implementation.setup(setupParams)).to.be.revertedWithCustomError(implementation, 'NotProxy');
+            // call setup on the implementation
+            await expect(implementation.setup(setupParams)).to.be.revertedWithCustomError(implementation, 'NotProxy');
+        });
     });
 });

--- a/test/upgradable/Upgradable.js
+++ b/test/upgradable/Upgradable.js
@@ -94,7 +94,7 @@ describe('Upgradable', () => {
         });
 
         it('should revert on upgrade with invalid code hash', async () => {
-            const invalidCodeHash = keccak256('0');
+            const invalidCodeHash = keccak256(0);
 
             await expect(upgradable.upgrade(upgradable.address, invalidCodeHash, '0x')).to.be.revertedWithCustomError(
                 upgradable,


### PR DESCRIPTION
* [x] `Upgradable`: storing new implementation before the delegate call to silent Slither warning