### PR TITLE
fix(InterchainMultisig): storage slot location

### DIFF
--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -10,9 +10,9 @@ import { ECDSA } from '../libs/ECDSA.sol';
     @notice Base contract to build a weighted multisig verification
 */
 abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
-    // keccak256('BaseWeightedMultisig.Slot');
+    // keccak256('BaseWeightedMultisig.Slot') - 1;
     bytes32 internal constant BASE_WEIGHTED_MULTISIG_SLOT =
-        0x457f3fc26bf430b020fe76358b1bfaba57e1657ace718da6437cda9934eabfe9;
+        0x457f3fc26bf430b020fe76358b1bfaba57e1657ace718da6437cda9934eabfe8;
 
     struct WeightedMultisigStorage {
         uint256 epoch;

--- a/contracts/governance/InterchainMultisig.sol
+++ b/contracts/governance/InterchainMultisig.sol
@@ -13,9 +13,9 @@ import { BaseWeightedMultisig } from './BaseWeightedMultisig.sol';
  * @notice Weighted Multisig executor to call functions on any contract
  */
 contract InterchainMultisig is Caller, BaseWeightedMultisig, IInterchainMultisig {
-    // keccak256('InterchainMultisig.Slot')
+    // keccak256('InterchainMultisig.Slot') - 1
     bytes32 internal constant INTERCHAIN_MULTISIG_SLOT =
-        0xee4c79745c2938ff2a269d76f8921d82df3b09446024c758a2e0e593fb2a65a8;
+        0xee4c79745c2938ff2a269d76f8921d82df3b09446024c758a2e0e593fb2a65a7;
 
     using SafeNativeTransfer for address;
 

--- a/contracts/test/governance/TestBaseWeightedMultisig.sol
+++ b/contracts/test/governance/TestBaseWeightedMultisig.sol
@@ -6,7 +6,7 @@ import { BaseWeightedMultisig } from '../../governance/BaseWeightedMultisig.sol'
 
 contract TestBaseWeightedMultisig is BaseWeightedMultisig {
     constructor(uint256 oldSignersRetention) BaseWeightedMultisig(oldSignersRetention) {
-        if (BASE_WEIGHTED_MULTISIG_SLOT != keccak256('BaseWeightedMultisig.Slot')) {
+        if (BASE_WEIGHTED_MULTISIG_SLOT != bytes32(uint256(keccak256('BaseWeightedMultisig.Slot')) - 1)) {
             revert('WeightedMultisig.Slot');
         }
     }

--- a/contracts/test/governance/TestInterchainMultisig.sol
+++ b/contracts/test/governance/TestInterchainMultisig.sol
@@ -8,7 +8,7 @@ contract TestInterchainMultisig is InterchainMultisig {
     constructor(string memory chainName, WeightedSigners memory weightedSigners)
         InterchainMultisig(chainName, weightedSigners)
     {
-        if (INTERCHAIN_MULTISIG_SLOT != keccak256('InterchainMultisig.Slot')) {
+        if (INTERCHAIN_MULTISIG_SLOT != bytes32(uint256(keccak256('InterchainMultisig.Slot')) - 1)) {
             revert('InterchainMultisig.Slot');
         }
     }


### PR DESCRIPTION
* [x] `BaseWeightedMultisig`, `InterchainMultisig`: using `keccak256() - 1` pattern for storage slot location.