### PR TITLE
refactor(amplifier)!: split message verification and signer rotation

### DIFF
--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -91,7 +91,7 @@ contract AxelarAmplifierGateway is IAxelarAmplifierGateway {
     function verifyMessages(SignedMessageBatch calldata signedBatch) public {
         bytes memory data = abi.encode(signedBatch.messages);
 
-        _validate(CommandType.VerifyMessages, data, signedBatch.proof);
+        _verifyProof(CommandType.VerifyMessages, data, signedBatch.proof);
 
         Message[] calldata messages = signedBatch.messages;
 
@@ -122,7 +122,7 @@ contract AxelarAmplifierGateway is IAxelarAmplifierGateway {
             revert CommandAlreadyExecuted(commandId);
         }
 
-        bool isLatestSigners = _validate(CommandType.RotateSigners, data, signedRotation.proof);
+        bool isLatestSigners = _verifyProof(CommandType.RotateSigners, data, signedRotation.proof);
         if (!isLatestSigners) {
             revert NotLatestSigners();
         }
@@ -136,7 +136,7 @@ contract AxelarAmplifierGateway is IAxelarAmplifierGateway {
     |* Internal Functions *|
     \**********************/
 
-    function _validate(CommandType commandType, bytes memory data, Proof calldata proof) internal view returns (bool) {
+    function _verifyProof(CommandType commandType, bytes memory data, Proof calldata proof) internal view returns (bool) {
         if (domainSeparator != proof.domainSeparator) revert InvalidDomainSeparator();
 
         // TODO: use SignData struct


### PR DESCRIPTION
Refactors #148 

Split contract call approval and key rotation commands into separate entrypoints. This avoids the complication of dealing with opaque Command type, and isolates key rotation checks, and command id derivation can be handled better.

`verifyMessages` and `rotateSigners` are the respective entrypoints. Proof validation logic is shared.

- [ ] add common `execute` entrypoint for convenience?
- [ ] update tests