### PR TITLE
fix(governance): add check for strict Multisig threshold validation

### DIFF
--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -53,7 +53,7 @@ contract AxelarAmplifierGateway is BaseAmplifierGateway, BaseWeightedMultisig, U
     function _setup(bytes calldata data) internal override {
         (address operator_, WeightedSigners[] memory signers) = abi.decode(data, (address, WeightedSigners[]));
 
-        // operator is an optional parameter. The gateway owner can set it later if needed.
+        // operator is an optional parameter. The gateway owner can set it later via `transferOperatorship` if needed.
         // This also simplifies setup for upgrades so if the current operator doesn't need to be changed, then it can be skipped, instead of having to specify the current operator again.
         if (operator_ != address(0)) {
             _transferOperatorship(operator_);

--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -126,6 +126,7 @@ contract AxelarAmplifierGateway is BaseAmplifierGateway, BaseWeightedMultisig, U
 
     /**
      * @notice Transfer the operatorship to a new address.
+     * @dev The owner or current operator can set the operator to address 0.
      * @param newOperator The address of the new operator.
      */
     function transferOperatorship(address newOperator) external onlyOperatorOrOwner {

--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -53,6 +53,7 @@ contract AxelarAmplifierGateway is BaseAmplifierGateway, BaseWeightedMultisig, U
     function _setup(bytes calldata data) internal override {
         (address operator_, WeightedSigners[] memory signers) = abi.decode(data, (address, WeightedSigners[]));
 
+        // operator is an optional parameter, it can also be removed in the future to make ownership completely decentralized
         if (operator_ != address(0)) {
             _transferOperatorship(operator_);
         }

--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -129,8 +129,6 @@ contract AxelarAmplifierGateway is BaseAmplifierGateway, BaseWeightedMultisig, U
      * @param newOperator The address of the new operator.
      */
     function transferOperatorship(address newOperator) external onlyOperatorOrOwner {
-        if (newOperator == address(0)) revert InvalidOperator();
-
         _transferOperatorship(newOperator);
     }
 

--- a/contracts/gateway/AxelarAmplifierGateway.sol
+++ b/contracts/gateway/AxelarAmplifierGateway.sol
@@ -53,7 +53,8 @@ contract AxelarAmplifierGateway is BaseAmplifierGateway, BaseWeightedMultisig, U
     function _setup(bytes calldata data) internal override {
         (address operator_, WeightedSigners[] memory signers) = abi.decode(data, (address, WeightedSigners[]));
 
-        // operator is an optional parameter, it can also be removed in the future to make ownership completely decentralized
+        // operator is an optional parameter. The gateway owner can set it later if needed.
+        // This also simplifies setup for upgrades so if the current operator doesn't need to be changed, then it can be skipped, instead of having to specify the current operator again.
         if (operator_ != address(0)) {
             _transferOperatorship(operator_);
         }

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -219,7 +219,7 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
 
             // weight needs to reach threshold
             if (totalWeight >= weightedSigners.threshold) {
-                // check if there are redundant signatures
+                // validate the proof if there are no redundant signatures
                 if (signaturesLength - i == 1) return;
 
                 revert RedundantSignaturesProvided(i + 1, signaturesLength);

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -220,7 +220,7 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
             // weight needs to reach threshold
             if (totalWeight >= weightedSigners.threshold) {
                 // validate the proof if there are no redundant signatures
-                if (signaturesLength - i == 1) return;
+                if (i + 1 == signaturesLength) return;
 
                 revert RedundantSignaturesProvided(i + 1, signaturesLength);
             }

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -219,9 +219,9 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
             // weight needs to reach threshold
             if (totalWeight >= weightedSigners.threshold) {
                 // check if number of signatures exceed required amount of signatures
-                if (signaturesLength - 1 != i) revert InvalidSignaturesLength(signaturesLength, i + 1);
+                if (signaturesLength - i == 1) return;
 
-                return;
+                revert ExcessiveSignaturesProvided(signaturesLength - i - 1);
             }
 
             // increasing signers index if match was found

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -107,6 +107,7 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
      * @param proof The multisig proof data
      * @return isLatestSigners True if the proof is from the latest signer set
      * @dev The proof data should have signers, weights, threshold and signatures encoded
+     *      The proof is only valid if signers weight crosses threshold and there are no redundant signatures
      *      The signers and signatures should be sorted by signer address in ascending order
      *      Example: abi.encode([0x11..., 0x22..., 0x33...], [1, 1, 1], 2, [signature1, signature3])
      */
@@ -218,10 +219,10 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
 
             // weight needs to reach threshold
             if (totalWeight >= weightedSigners.threshold) {
-                // check if number of signatures exceed required amount of signatures
+                // check if there are redundant signatures
                 if (signaturesLength - i == 1) return;
 
-                revert ExcessiveSignaturesProvided(signaturesLength - i - 1);
+                revert RedundantSignaturesProvided(i + 1, signaturesLength);
             }
 
             // increasing signers index if match was found

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -107,7 +107,7 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
      * @param proof The multisig proof data
      * @return isLatestSigners True if the proof is from the latest signer set
      * @dev The proof data should have signers, weights, threshold and signatures encoded
-     *      The proof is only valid if signers weight crosses threshold and there are no redundant signatures
+     *      The proof is only valid if the signers weight crosses the threshold and there are no redundant signatures
      *      The signers and signatures should be sorted by signer address in ascending order
      *      Example: abi.encode([0x11..., 0x22..., 0x33...], [1, 1, 1], 2, [signature1, signature3])
      */

--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -216,8 +216,13 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
             // accumulating signatures weight
             totalWeight = totalWeight + signers[signerIndex].weight;
 
-            // weight needs to reach or surpass threshold
-            if (totalWeight >= weightedSigners.threshold) return;
+            // weight needs to reach threshold
+            if (totalWeight >= weightedSigners.threshold) {
+                // check if number of signatures exceed required amount of signatures
+                if (signaturesLength - 1 != i) revert InvalidSignaturesLength(signaturesLength, i + 1);
+
+                return;
+            }
 
             // increasing signers index if match was found
             ++signerIndex;

--- a/contracts/interfaces/IAxelarAmplifierGateway.sol
+++ b/contracts/interfaces/IAxelarAmplifierGateway.sol
@@ -16,7 +16,6 @@ import { Message } from '../types/AmplifierGatewayTypes.sol';
 interface IAxelarAmplifierGateway is IBaseAmplifierGateway, IBaseWeightedMultisig, IUpgradable {
     error NotLatestSigners();
     error InvalidSender(address sender);
-    error InvalidOperator();
 
     event OperatorshipTransferred(address newOperator);
 

--- a/contracts/interfaces/IBaseWeightedMultisig.sol
+++ b/contracts/interfaces/IBaseWeightedMultisig.sol
@@ -9,6 +9,7 @@ interface IBaseWeightedMultisig {
     error LowSignaturesWeight();
     error InvalidWeights();
     error DuplicateSigners(bytes32 signersHash);
+    error InvalidSignaturesLength(uint256 provided, uint256 required);
     error InsufficientRotationDelay(uint256 minimumRotationDelay, uint256 lastRotationTimestamp, uint256 timeElapsed);
 
     event SignersRotated(uint256 indexed epoch, bytes32 indexed signersHash, bytes signers);

--- a/contracts/interfaces/IBaseWeightedMultisig.sol
+++ b/contracts/interfaces/IBaseWeightedMultisig.sol
@@ -9,7 +9,7 @@ interface IBaseWeightedMultisig {
     error LowSignaturesWeight();
     error InvalidWeights();
     error DuplicateSigners(bytes32 signersHash);
-    error InvalidSignaturesLength(uint256 provided, uint256 required);
+    error ExcessiveSignaturesProvided(uint256 difference);
     error InsufficientRotationDelay(uint256 minimumRotationDelay, uint256 lastRotationTimestamp, uint256 timeElapsed);
 
     event SignersRotated(uint256 indexed epoch, bytes32 indexed signersHash, bytes signers);

--- a/contracts/interfaces/IBaseWeightedMultisig.sol
+++ b/contracts/interfaces/IBaseWeightedMultisig.sol
@@ -9,7 +9,7 @@ interface IBaseWeightedMultisig {
     error LowSignaturesWeight();
     error InvalidWeights();
     error DuplicateSigners(bytes32 signersHash);
-    error ExcessiveSignaturesProvided(uint256 difference);
+    error RedundantSignaturesProvided(uint256 required, uint256 provided);
     error InsufficientRotationDelay(uint256 minimumRotationDelay, uint256 lastRotationTimestamp, uint256 timeElapsed);
 
     event SignersRotated(uint256 indexed epoch, bytes32 indexed signersHash, bytes signers);

--- a/test/gateway/AxelarAmplifierGateway.js
+++ b/test/gateway/AxelarAmplifierGateway.js
@@ -212,28 +212,10 @@ describe('AxelarAmplifierGateway', () => {
             expect(await gateway.operator()).to.equal(operator.address);
         });
 
-        it('should allow deploying gateway with address 0 as the operator', async () => {
-            const signers = defaultAbiCoder.encode(
-                ['address', `${WEIGHTED_SIGNERS_TYPE}[]`],
-                [AddressZero, [weightedSigners]],
-            );
-
-            const implementation = await gatewayFactory.deploy(
-                previousSignersRetention,
-                domainSeparator,
-                minimumRotationDelay,
-            );
-            await implementation.deployTransaction.wait(network.config.confirmations);
-
-            const proxy = await gatewayProxyFactory.deploy(
-                implementation.address,
-                owner.address,
-                signers,
-                getGasOptions(),
-            );
-            await proxy.deployTransaction.wait(network.config.confirmations);
-
-            const gateway = gatewayFactory.attach(proxy.address);
+        it('should allow transferring operatorship to the zero address', async () => {
+            await expect(gateway.connect(owner).transferOperatorship(AddressZero))
+                .to.emit(gateway, 'OperatorshipTransferred')
+                .withArgs(AddressZero);
 
             expect(await gateway.operator()).to.equal(AddressZero);
         });
@@ -252,14 +234,6 @@ describe('AxelarAmplifierGateway', () => {
                 gateway,
                 'InvalidSender',
                 [user.address],
-            );
-        });
-
-        it('reject transferring operatorship to the zero address', async () => {
-            await expectRevert(
-                (gasOptions) => gateway.connect(operator).transferOperatorship(AddressZero, gasOptions),
-                gateway,
-                'InvalidOperator',
             );
         });
     });

--- a/test/gateway/AxelarAmplifierGateway.js
+++ b/test/gateway/AxelarAmplifierGateway.js
@@ -218,7 +218,7 @@ describe('AxelarAmplifierGateway', () => {
                 [AddressZero, [weightedSigners]],
             );
 
-            implementation = await gatewayFactory.deploy(
+            const implementation = await gatewayFactory.deploy(
                 previousSignersRetention,
                 domainSeparator,
                 minimumRotationDelay,
@@ -233,7 +233,7 @@ describe('AxelarAmplifierGateway', () => {
             );
             await proxy.deployTransaction.wait(network.config.confirmations);
 
-            gateway = gatewayFactory.attach(proxy.address);
+            const gateway = gatewayFactory.attach(proxy.address);
 
             expect(await gateway.operator()).to.equal(AddressZero);
         });

--- a/test/governance/BaseWeightedMultisig.js
+++ b/test/governance/BaseWeightedMultisig.js
@@ -374,14 +374,6 @@ describe('BaseWeightedMultisig', () => {
                 await multisig.validateProofCall(dataHash, proof).then((tx) => tx.wait());
             });
 
-            it('validate the proof from the current signers with extra signatures', async () => {
-                // sign with all signers, i.e more than threshold
-                const proof = await getWeightedSignersProof(data, domainSeparator, weightedSigners, signers);
-
-                const isCurrentSigners = await multisig.validateProof(dataHash, proof);
-                expect(isCurrentSigners).to.be.true;
-            });
-
             it('validate the proof with last threshold signers', async () => {
                 const proof = await getWeightedSignersProof(
                     data,
@@ -479,6 +471,18 @@ describe('BaseWeightedMultisig', () => {
                     async (gasOptions) => multisig.validateProof(dataHash, proof, gasOptions),
                     multisig,
                     'LowSignaturesWeight',
+                );
+            });
+
+            it('reject the proof if number of total signatures exceed required signatures', async () => {
+                // sign with all signers, i.e more than threshold
+                const proof = await getWeightedSignersProof(data, domainSeparator, weightedSigners, signers);
+
+                await expectRevert(
+                    async (gasOptions) => multisig.validateProof(dataHash, proof),
+                    multisig,
+                    'InvalidSignaturesLength',
+                    [proof.signatures.length, signers.slice(0, threshold)],
                 );
             });
         });

--- a/test/governance/BaseWeightedMultisig.js
+++ b/test/governance/BaseWeightedMultisig.js
@@ -481,8 +481,8 @@ describe('BaseWeightedMultisig', () => {
                 await expectRevert(
                     async (gasOptions) => multisig.validateProof(dataHash, proof),
                     multisig,
-                    'InvalidSignaturesLength',
-                    [proof.signatures.length, signers.slice(0, threshold)],
+                    'ExcessiveSignaturesProvided',
+                    [proof.signatures.length - signers.slice(0, threshold)],
                 );
             });
         });

--- a/test/governance/BaseWeightedMultisig.js
+++ b/test/governance/BaseWeightedMultisig.js
@@ -474,15 +474,15 @@ describe('BaseWeightedMultisig', () => {
                 );
             });
 
-            it('reject the proof if number of total signatures exceed required signatures', async () => {
+            it('reject the proof if there are redundant signatures', async () => {
                 // sign with all signers, i.e more than threshold
                 const proof = await getWeightedSignersProof(data, domainSeparator, weightedSigners, signers);
 
                 await expectRevert(
                     async (gasOptions) => multisig.validateProof(dataHash, proof),
                     multisig,
-                    'ExcessiveSignaturesProvided',
-                    [proof.signatures.length - signers.slice(0, threshold)],
+                    'RedundantSignaturesProvided',
+                    [signers.slice(0, threshold), proof.signatures.length],
                 );
             });
         });


### PR DESCRIPTION
# Strict Weighted Multisig threshold validation
This PR adds a check to revert if there are any leftover signatures, when threshold is crossed to make the threshold validation strict.

- [x] add error and check in smart contract for strict validation.
- [x] remove positive test for signatures exceeding required signatures.
- [x] add negative test to revert in case of signatures exceeding required signatures.
- [x] add comment stating operator is an optional param in setup, which can be removed in the future
- [x] remove check for transferring operator role to address 0.

[Jira Ticket](https://axelarnetwork.atlassian.net/browse/AXE-4308)