### PR TITLE
fix(storageLayout, readme): update hardhat config for storageLayout and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ REPORT_GAS=true npm run test
 
 Check storage layout of contracts.
 ```bash
-STORAGE_LAYOUT=true npx hardhat check
+STORAGE_LAYOUT=true npm run check
 ```
 
 Check contract bytecode size

--- a/contracts/gateway/README.md
+++ b/contracts/gateway/README.md
@@ -4,6 +4,10 @@ Axelar Amplifier Gateway is a smart contract that lives on the external chain th
 
 Please see the [INTEGRATION.md](INTEGRATION.md) for more details on how to implement and integrate the external gateway contract for a given chain.
 
+## Documentation & Build
+
+Please refer to [README.md](../../README.md) for documentation and build instructions.
+
 ## Deployment
 
 The official `AxelarAmplifierGateway` contract deployment scripts are located in this [repo](https://github.com/axelarnetwork/axelar-contract-deployments/tree/main/evm#evm-deployment-scripts).

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,6 +9,7 @@ if (process.env.CHECK_CONTRACT_SIZE) {
     require('hardhat-contract-sizer');
 }
 
+
 const { importNetworks, readJSON } = require('@axelar-network/axelar-chains-config');
 
 const env = process.env.ENV || 'testnet';

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -35,11 +35,18 @@ const optimizerSettings = {
     },
 };
 
+const outputSelectionSettings = {
+    "*": {
+        "*": ["storageLayout"],
+    },
+};
+
 const defaultSettings = {
     version: '0.8.23',
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
+        outputSelection: outputSelectionSettings,
     },
 };
 
@@ -49,6 +56,7 @@ const compilerSettings = {
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
+        outputSelection: outputSelectionSettings,
     },
 };
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -37,18 +37,20 @@ const optimizerSettings = {
 
 // Need to manually specify outputSelection settings for the hardhat-storage-layout plugin since we're using customized compiler settings.
 // https://www.npmjs.com/package/hardhat-storage-layout?activeTab=code
-const outputSelectionSettings = {
-    "*": {
-        "*": ["storageLayout"],
-    },
-};
+const outputSelectionSettings = process.env.STORAGE_LAYOUT
+    ? {
+          '*': {
+              '*': ['storageLayout'],
+          },
+      }
+    : {};
 
 const defaultSettings = {
     version: '0.8.23',
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
-        outputSelection: process.env.STORAGE_LAYOUT ? {} : outputSelectionSettings,
+        outputSelection: outputSelectionSettings,
     },
 };
 
@@ -58,7 +60,7 @@ const compilerSettings = {
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
-        outputSelection: process.env.STORAGE_LAYOUT ? {} : outputSelectionSettings,
+        outputSelection: outputSelectionSettings,
     },
 };
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,7 +9,6 @@ if (process.env.CHECK_CONTRACT_SIZE) {
     require('hardhat-contract-sizer');
 }
 
-
 const { importNetworks, readJSON } = require('@axelar-network/axelar-chains-config');
 
 const env = process.env.ENV || 'testnet';
@@ -36,6 +35,8 @@ const optimizerSettings = {
     },
 };
 
+// Need to manually specify outputSelection settings for the hardhat-storage-layout plugin since we're using customized compiler settings.
+// https://www.npmjs.com/package/hardhat-storage-layout?activeTab=code
 const outputSelectionSettings = {
     "*": {
         "*": ["storageLayout"],
@@ -47,7 +48,7 @@ const defaultSettings = {
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
-        outputSelection: outputSelectionSettings,
+        outputSelection: process.env.STORAGE_LAYOUT ? {} : outputSelectionSettings,
     },
 };
 
@@ -57,7 +58,7 @@ const compilerSettings = {
     settings: {
         evmVersion: process.env.EVM_VERSION || 'london',
         optimizer: optimizerSettings,
-        outputSelection: outputSelectionSettings,
+        outputSelection: process.env.STORAGE_LAYOUT ? {} : outputSelectionSettings,
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npx hardhat clean && npx hardhat compile && npm run copy:interfaces",
     "test": "npx hardhat test",
+    "check": "npx hardhat clean && npx hardhat compile && npx hardhat check",
     "test-evm-versions": "bash scripts/test-evm-versions.sh",
     "copy:interfaces": "rm -rf interfaces && mkdir interfaces && cp artifacts/contracts/interfaces/*/*.json interfaces/ && rm interfaces/*.dbg.json",
     "clean:artifacts": "rm -rf artifacts/build-info artifacts/*/test artifacts/contracts/*/*/*.dbg.json",


### PR DESCRIPTION
## Issue:
[AXE-4606](https://axelarnetwork.atlassian.net/browse/AXE-4606) 

Executing the command `STORAGE_LAYOUT=true npx hardhat check` returns:
```
Table has empty fields
```
## Fix
added outputSelection configuration for storageLayout.
## After Fix:
`STORAGE_LAYOUT=true npm run check`
```
┌───────────────────────────────────┬──────────────────────┬──────────────┬────────┬────────────────────────────────────────────────────────────────────────┬─────┬───────────────────────────────────────────────────┬───────────────┐
│             contract              │    state_variable    │ storage_slot │ offset │                                  type                                  │ idx │                     artifact                      │ numberOfBytes │
├───────────────────────────────────┼──────────────────────┼──────────────┼────────┼────────────────────────────────────────────────────────────────────────┼─────┼───────────────────────────────────────────────────┼───────────────┤
│      AxelarServiceGovernance      │   governanceChain    │      0       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│      AxelarServiceGovernance      │  governanceAddress   │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│      AxelarServiceGovernance      │       multisig       │      2       │   0    │                               t_address                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│      AxelarServiceGovernance      │  multisigApprovals   │      3       │   0    │                      t_mapping(t_bytes32,t_bool)                       │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│ AxelarValuedExpressExecutableTest │      callValue       │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│ AxelarValuedExpressExecutableTest │  callWithTokenValue  │      1       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│ AxelarValuedExpressExecutableTest │     expressToken     │      2       │   0    │                               t_address                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│           BaseMultisig            │       signers        │      0       │   0    │                     t_struct(Signers)3567_storage                      │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      96       │
│           BaseMultisig            │     signerEpoch      │      3       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│           BaseMultisig            │    votingPerTopic    │      4       │   0    │ t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Voting)3557_storage)) │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│           BaseMultisig            │       signers        │      0       │   0    │                      t_struct(Signers)23_storage                       │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      96       │
│           BaseMultisig            │     signerEpoch      │      3       │   0    │                               t_uint256                                │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      32       │
│           BaseMultisig            │    votingPerTopic    │      4       │   0    │  t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Voting)13_storage))  │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      32       │
│   DestinationChainTokenSwapper    │        tokenA        │      0       │   0    │                               t_address                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│   DestinationChainTokenSwapper    │        tokenB        │      1       │   0    │                               t_address                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│   DifferentProxyImplementation    │        value         │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│   DifferentProxyImplementation    │         name         │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│               ERC20               │      balanceOf       │      0       │   0    │                     t_mapping(t_address,t_uint256)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│               ERC20               │      allowance       │      1       │   0    │          t_mapping(t_address,t_mapping(t_address,t_uint256))           │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│               ERC20               │     totalSupply      │      2       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│               ERC20               │         name         │      3       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│               ERC20               │        symbol        │      4       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       ERC20MintableBurnable       │      balanceOf       │      0       │   0    │                     t_mapping(t_address,t_uint256)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       ERC20MintableBurnable       │      allowance       │      1       │   0    │          t_mapping(t_address,t_mapping(t_address,t_uint256))           │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       ERC20MintableBurnable       │     totalSupply      │      2       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       ERC20MintableBurnable       │         name         │      3       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       ERC20MintableBurnable       │        symbol        │      4       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     ERC20MintableBurnableInit     │      balanceOf       │      0       │   0    │                     t_mapping(t_address,t_uint256)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     ERC20MintableBurnableInit     │      allowance       │      1       │   0    │          t_mapping(t_address,t_mapping(t_address,t_uint256))           │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     ERC20MintableBurnableInit     │     totalSupply      │      2       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     ERC20MintableBurnableInit     │         name         │      3       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     ERC20MintableBurnableInit     │        symbol        │      4       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         ExecutableSample          │        value         │      0       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         ExecutableSample          │     sourceChain      │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         ExecutableSample          │    sourceAddress     │      2       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│        FixedImplementation        │        value         │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       InterchainGovernance        │   governanceChain    │      0       │   0    │                            t_string_storage                            │  1  │ /build-info/37f6c6ce0b0dcaa7a2943902d1c8ce2f.json │      32       │
│       InterchainGovernance        │  governanceAddress   │      1       │   0    │                            t_string_storage                            │  1  │ /build-info/37f6c6ce0b0dcaa7a2943902d1c8ce2f.json │      32       │
│       InterchainGovernance        │   governanceChain    │      0       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       InterchainGovernance        │  governanceAddress   │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            MockGateway            │        bools         │      0       │   0    │                      t_mapping(t_bytes32,t_bool)                       │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            MockGateway            │      addresses       │      1       │   0    │                     t_mapping(t_bytes32,t_address)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            MockGateway            │        uints         │      2       │   0    │                     t_mapping(t_bytes32,t_uint256)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            MockGateway            │       strings        │      3       │   0    │                 t_mapping(t_bytes32,t_string_storage)                  │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            MockGateway            │       bytes32s       │      4       │   0    │                     t_mapping(t_bytes32,t_bytes32)                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│             Multisig              │       signers        │      0       │   0    │                      t_struct(Signers)23_storage                       │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      96       │
│             Multisig              │     signerEpoch      │      3       │   0    │                               t_uint256                                │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      32       │
│             Multisig              │    votingPerTopic    │      4       │   0    │  t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Voting)13_storage))  │  5  │ /build-info/62eedd0ba5425b53bf19cd779a831736.json │      32       │
│             Operators             │      operators       │      0       │   0    │                      t_mapping(t_address,t_bool)                       │  7  │ /build-info/c3a10429a6a58806b1f2f298138f183a.json │      32       │
│        ProxyImplementation        │        value         │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│        ProxyImplementation        │         name         │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         SourceChainSender         │       gateway        │      0       │   0    │                     t_contract(IAxelarGateway)6662                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│         SourceChainSender         │   destinationChain   │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         SourceChainSender         │  executableAddress   │      2       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       SourceChainSwapCaller       │       gateway        │      0       │   0    │                     t_contract(IAxelarGateway)6662                     │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      20       │
│       SourceChainSwapCaller       │   destinationChain   │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│       SourceChainSwapCaller       │  executableAddress   │      2       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         TestBaseMultisig          │       signers        │      0       │   0    │                     t_struct(Signers)3567_storage                      │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      96       │
│         TestBaseMultisig          │     signerEpoch      │      3       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│         TestBaseMultisig          │    votingPerTopic    │      4       │   0    │ t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Voting)3557_storage)) │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│        TestImplementation         │         val          │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│   TestInterchainAddressTracker    │         name         │      0       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     TestInterchainGovernance      │   governanceChain    │      0       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│     TestInterchainGovernance      │  governanceAddress   │      1       │   0    │                            t_string_storage                            │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│           TestMulticall           │        nonce         │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│           TestMulticall           │ lastMulticallReturns │      1       │   0    │                  t_array(t_bytes_storage)dyn_storage                   │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│            TestOwnable            │         num          │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│        TestReentrancyGuard        │        value         │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│             TestRoles             │         num          │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│          TestUpgradable           │         num          │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
│           TimeLockTest            │         num          │      0       │   0    │                               t_uint256                                │  4  │ /build-info/60bb168fe67f6c0d00e938528f838df5.json │      32       │
└───────────────────────────────────┴──────────────────────┴──────────────┴────────┴────────────────────────────────────────────────────────────────────────┴─────┴───────────────────────────────────────────────────┴───────────────┘
```

[AXE-4606]: https://axelarnetwork.atlassian.net/browse/AXE-4606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ