### PR TITLE
fix: remove redundant check

### DIFF
--- a/contracts/governance/BaseWeightedMultisig.sol
+++ b/contracts/governance/BaseWeightedMultisig.sol
@@ -200,8 +200,6 @@ abstract contract BaseWeightedMultisig is IBaseWeightedMultisig {
         uint256 signerIndex;
         uint256 totalWeight;
 
-        if (signaturesLength == 0) revert LowSignaturesWeight();
-
         // looking for signers within signers
         // this requires both signers and signatures to be sorted
         // having it sorted allows us to avoid the full inner loop to find a match


### PR DESCRIPTION
[AXE-4743](https://axelarnetwork.atlassian.net/browse/AXE-4743): Remove Rrdundant check for signature weights in `_validateSignatures`

[AXE-4743]: https://axelarnetwork.atlassian.net/browse/AXE-4743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ