### PR TITLE
ci: add public access for the publish config

### DIFF
--- a/.changeset/beige-masks-roll.md
+++ b/.changeset/beige-masks-roll.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-gmp-sdk-solidity': patch
+---
+
+add public access for the publish config

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "artifacts",
     "contracts",


### PR DESCRIPTION
# What:

- Add the public access publish config to set the visibility of the package to `public`